### PR TITLE
Include Doc Builds in the GHA CI workflow

### DIFF
--- a/.github/workflows/quicktest-dev-pr.yml
+++ b/.github/workflows/quicktest-dev-pr.yml
@@ -28,4 +28,12 @@ jobs:
 
       - name: Run Tests
         run: |
-          docker run --rm -v $(pwd):/workspace/finn-base finn-base-gha run_tests.sh
+          docker run --rm \
+                     -v $(pwd):/workspace/finn-base \
+                     finn-base-gha run_tests.sh
+
+      - name: Build Docs
+        run: |
+          docker run --rm \
+                     -v $(pwd):/workspace/finn-base \
+                     finn-base-gha build_docs.sh

--- a/setup.cfg
+++ b/setup.cfg
@@ -98,6 +98,7 @@ universal = 1
 [build_sphinx]
 source-dir = docs
 build-dir = docs/_build
+warning-is-error = 1
 
 [devpi:upload]
 # Options for the devpi: PyPI server and packaging tool


### PR DESCRIPTION
Add docs build to the GHA CI workflow. Configured sphinx builds to treat warnings as errors that are then caught by GHA.